### PR TITLE
Remove MicaOS link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ LunaOS | https://github.com/TheLunaOS
 Lunaris-AOSP | https://github.com/Lunaris-AOSP
 LumineDroid | https://github.com/LumineDroid
 Lynx-AOSP | https://github.com/Lynx-AOSP
-MicaOS | https://github.com/Project-Mica
 Miku UI  | https://github.com/Miku-UI
 MinusOS | https://github.com/Project-MinusOS
 Neoteric-OS | https://github.com/Neoteric-OS


### PR DESCRIPTION
Removed MicaOS link since the rom isn't actively maintained anymore as announced in the project telegram. (https://t.me/aswinaskurup/788)